### PR TITLE
Fix refresh token revocation check

### DIFF
--- a/AuthServicePlus.Persistence/Repositories/UserRepository.cs
+++ b/AuthServicePlus.Persistence/Repositories/UserRepository.cs
@@ -61,9 +61,9 @@ namespace AuthServicePlus.Persistence.Repositories
         public bool RevokeRefreshToken(User user, string token)
         {
             var rt = user.RefreshTokens.FirstOrDefault(t => t.Token == token);
-            if (rt != null || rt.RevokedAt != null)
+            if (rt == null || rt.RevokedAt != null)
                 return false;
-        
+
             rt.RevokedAt = DateTime.UtcNow;
             return true;
         }


### PR DESCRIPTION
## Summary
- исправлена проверка условия при отзыве refresh-токена, чтобы корректно обрабатывать отсутствующий и уже отозванный токен

## Testing
- not run (dotnet CLI недоступен в окружении)


------
https://chatgpt.com/codex/tasks/task_e_68d073f6630c8332947b030295226bb9