### PR TITLE
Fix refresh token handling and configuration usage

### DIFF
--- a/AuthServicePlus.Persistence/Repositories/UserRepository.cs
+++ b/AuthServicePlus.Persistence/Repositories/UserRepository.cs
@@ -19,7 +19,7 @@ namespace AuthServicePlus.Persistence.Repositories
         {
             var query = _context.Users.Include(u => u.RefreshTokens).AsQueryable();
             if (!track) query = query.AsNoTracking();
-            return await _context.Users.SingleOrDefaultAsync(u => u.Username == username);
+            return await query.SingleOrDefaultAsync(u => u.Username == username);
         }
 
         public async Task AddUserAsync(User user)
@@ -61,7 +61,7 @@ namespace AuthServicePlus.Persistence.Repositories
         public bool RevokeRefreshToken(User user, string token)
         {
             var rt = user.RefreshTokens.FirstOrDefault(t => t.Token == token);
-            if (rt != null || rt.RevokedAt != null)
+            if (rt == null || rt.RevokedAt != null)
                 return false;
         
             rt.RevokedAt = DateTime.UtcNow;


### PR DESCRIPTION
## Summary
- fix AuthService namespace and align token lifetimes with configuration values
- ensure refresh token rotation stores options-based lifetime for replacement tokens
- correct user repository queries and guard conditions when revoking refresh tokens

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d074eddac08332b138baa5c97cb876