### PR TITLE
Add structured logging to API controllers

### DIFF
--- a/AuthServicePlus.Api/Controllers/AdminController.cs
+++ b/AuthServicePlus.Api/Controllers/AdminController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace AuthServicePlus.Api.Controllers
 {
@@ -7,8 +8,21 @@ namespace AuthServicePlus.Api.Controllers
     [Route("admin")]
     public class AdminController: ControllerBase
     {
+        private readonly ILogger<AdminController> _logger;
+
+        public AdminController(ILogger<AdminController> logger)
+        {
+            _logger = logger;
+        }
+
         [Authorize(Roles ="Admin")]
         [HttpGet("ping")]
-        public IActionResult Ping() => Ok(new {Ok = true, at = DateTime.UtcNow});
+        public IActionResult Ping()
+        {
+            _logger.LogInformation("Поступил административный запрос ping");
+            var response = new { Ok = true, at = DateTime.UtcNow };
+            _logger.LogInformation("Возвращаем ответ на административный ping");
+            return Ok(response);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add detailed logging around authentication controller actions to track success and failure cases
- introduce logging to the admin ping endpoint for better observability

## Testing
- dotnet test *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68f4056623a08332a286aeed6473aed8